### PR TITLE
Make stack traces work with the noConflict method of including jQuery

### DIFF
--- a/memcache_toolbar/panels/__init__.py
+++ b/memcache_toolbar/panels/__init__.py
@@ -59,9 +59,8 @@ def record(func):
             stacktrace = tidy_stacktrace(traceback.extract_stack())
         else:
             stacktrace = []
-        call = {'function': func.__name__, 'args': None, 
+        call = {'function': func.__name__, 'args': None,
                 'stacktrace': stacktrace}
-        instance.append(call)
         # the try here is just being extra safe, it should not happen
         try:
             a = None
@@ -85,6 +84,7 @@ def record(func):
             # the clock stops now
             dur = datetime.now() - call['start']
             call['duration'] = (dur.seconds * 1000) + (dur.microseconds / 1000.0)
+            instance.append(call)
         return ret
     return recorder
 

--- a/memcache_toolbar/panels/__init__.py
+++ b/memcache_toolbar/panels/__init__.py
@@ -55,7 +55,10 @@ def tidy_stacktrace(strace):
 
 def record(func):
     def recorder(*args, **kwargs):
-        stacktrace = tidy_stacktrace(traceback.extract_stack())
+        if getattr(settings, 'DEBUG_TOOLBAR_CONFIG', {}).get('ENABLE_STACKTRACES', True):
+            stacktrace = tidy_stacktrace(traceback.extract_stack())
+        else:
+            stacktrace = []
         call = {'function': func.__name__, 'args': None, 
                 'stacktrace': stacktrace}
         instance.append(call)

--- a/memcache_toolbar/templates/memcache_toolbar/panels/memcache.html
+++ b/memcache_toolbar/templates/memcache_toolbar/panels/memcache.html
@@ -59,29 +59,16 @@
     </tbody>
 </table>
 <script type="text/javascript">
-// the way ddt is using jquery we can't get at it after the fact.  our options
-// are to reload the whole thing or to not use jquery, for now we'll reload...
-// :( this is just about a copy of toolbar.js from ddt
-(function(window, document, version, callback) {
-    var j, d;
-    var loaded = false;
-    if (!(j = window.jQuery) || version > j.fn.jquery || callback(j)) {
-        var script = document.createElement("script");
-        script.type = "text/javascript";
-        script.src = DEBUG_TOOLBAR_MEDIA_URL + "js/jquery.js";
-        script.onload = script.onreadystatechange = function() {
-            if (!loaded && (!(d = this.readyState) || d == "loaded" || d == "complete")) {
-                callback((j = window.jQuery).noConflict(1), loaded = true);
-                j(script).remove();
-            }
-        };
-        document.documentElement.childNodes[0].appendChild(script)
-    }
-})(window, document, "1.3", function($, jquery_loaded) {
-    $('a.djMemcacheShowStacktrace').click(function(ev) {
-        ev.preventDefault();
-        $(this).parent().parent().next().toggle();
-        return false;
+// the way ddt is using jquery we can't get at it after the fact in the usual
+// manner
+(function(window, document) {
+    var j = window.djdt.jQuery;
+    j(document).ready(function() {
+        j('a.djMemcacheShowStacktrace').click(function(ev) {
+            ev.preventDefault();
+            j(this).parent().parent().next().toggle();
+            return false;
+        });
     });
-});
+})(window, document);
 </script>

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='memcache_toolbar',
-    version='0.5.4',
+    version='0.5.5',
     description='',
     author='Ross McFarland',
     author_email='rwmcfa1@neces.com',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='memcache_toolbar',
-    version='0.5.3',
+    version='0.5.4',
     description='',
     author='Ross McFarland',
     author_email='rwmcfa1@neces.com',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='memcache_toolbar',
-    version='0.5.2',
+    version='0.5.3',
     description='',
     author='Ross McFarland',
     author_email='rwmcfa1@neces.com',


### PR DESCRIPTION
Stack traces don't work when you use this with newest version of django debug toolbar
