### PR TITLE
Add support to new Django-Debug-Toolbar

### DIFF
--- a/memcache_toolbar/panels/__init__.py
+++ b/memcache_toolbar/panels/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 from datetime import datetime
-from debug_toolbar.panels import DebugPanel
+from debug_toolbar.panels import Panel
 from django.conf import settings
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
@@ -86,7 +86,7 @@ def record(func):
     return recorder
 
 
-class BasePanel(DebugPanel):
+class BasePanel(Panel):
     name = 'Memcache'
     has_content = True
 

--- a/memcache_toolbar/panels/__init__.py
+++ b/memcache_toolbar/panels/__init__.py
@@ -93,9 +93,11 @@ class BasePanel(Panel):
     def process_request(self, request):
         instance.reset()
 
+    @property
     def nav_title(self):
         return _('Memcache')
 
+    @property
     def nav_subtitle(self):
         duration = 0
         calls = instance.calls()
@@ -107,24 +109,30 @@ class BasePanel(Panel):
         else:
             return "0 calls"
 
+    @property
     def title(self):
         return _('Memcache Calls')
 
+    @property
     def url(self):
         return ''
 
+    @property
+    def template(self):
+        return 'memcache_toolbar/panels/memcache.html'
+
+    @property
     def content(self):
         duration = 0
         calls = instance.calls()
         for call in calls:
             duration += call['duration']
 
-        context = self.context.copy()
-        context.update({
+        context = {
             'calls': calls,
             'count': len(calls),
             'duration': duration,
-        })
+        }
 
-        return render_to_string('memcache_toolbar/panels/memcache.html',
+        return render_to_string(self.template,
                 context)


### PR DESCRIPTION
The panel doesn't work in Django-Debug-Toolbar v1.0.1, add support.
